### PR TITLE
Add quotes to table name to support cased tables

### DIFF
--- a/postgres-direct/mk-logical-repl.sh
+++ b/postgres-direct/mk-logical-repl.sh
@@ -46,7 +46,7 @@ psql "$PRIMARY" -c "CREATE PUBLICATION _planetscale_import;" || :
 psql "$PRIMARY" -A -c '\dt' -t |
 cut -d "|" -f "2" |
 while read TABLE
-do psql "$PRIMARY" -c "ALTER PUBLICATION _planetscale_import ADD TABLE $TABLE;"
+do psql "$PRIMARY" -c "ALTER PUBLICATION _planetscale_import ADD TABLE \"$TABLE\";"
 done
 
 # Import the primary's schema.


### PR DESCRIPTION
- Currently cased tables cause an error, this wraps it in quotes to support them