### PR TITLE
Fix getting last migration directory picking a regular file

### DIFF
--- a/pgcopydb-helpers/AGENTS.md
+++ b/pgcopydb-helpers/AGENTS.md
@@ -240,8 +240,8 @@ Displays CDC-specific replication progress: apply and streaming LSN positions, b
 Resumes a previously interrupted `pgcopydb clone --follow` migration. Backs up the SQLite catalog before resuming.
 
 ```bash
-~/resume-migration.sh                          # uses most recent migration dir
-~/resume-migration.sh ~/migration_YYYYMMDD-HHMMSS  # specify explicitly
+~/resume-migration.sh                                                    # uses most recent migration dir
+MIGRATION_DIR=~/migration_YYYYMMDD-HHMMSS ~/resume-migration.sh          # specify explicitly
 ```
 
 **Important:** The script passes `--split-tables-larger-than` to match `run-migration.sh`. pgcopydb requires catalog consistency — if the original run used split tables, the resume must pass the same value.
@@ -303,7 +303,7 @@ psql "$PGCOPYDB_SOURCE_PGURI" -t -A -c "SELECT pg_current_wal_lsn();"
 
 # Set the endpoint
 ~/stop_cdc.sh 41EBA/7C7A1AD8
-~/stop_cdc.sh 41EBA/7C7A1AD8 ~/migration_YYYYMMDD-HHMMSS  # explicit dir
+MIGRATION_DIR=~/migration_YYYYMMDD-HHMMSS ~/stop_cdc.sh 41EBA/7C7A1AD8  # explicit dir
 ```
 
 **Cutover procedure:**

--- a/pgcopydb-helpers/README.md
+++ b/pgcopydb-helpers/README.md
@@ -186,7 +186,7 @@ When `check-cdc-status.sh` reports **"CDC IS CAUGHT UP"** (apply backlog < 100 M
 
    ```bash
    ~/stop_cdc.sh <LSN>
-   ~/stop_cdc.sh <LSN> ~/migration_YYYYMMDD-HHMMSS  # explicit dir
+   MIGRATION_DIR=~/migration_YYYYMMDD-HHMMSS ~/stop_cdc.sh <LSN>  # explicit dir
    ```
 
 4. **Wait** for pgcopydb to apply all remaining changes and exit. Monitor with `check-cdc-status.sh`.
@@ -211,8 +211,8 @@ This drops the replication slot on the source, the replication origin on the tar
 If pgcopydb crashes, the instance reboots, or the migration is interrupted:
 
 ```bash
-~/resume-migration.sh                              # uses most recent migration dir
-~/resume-migration.sh ~/migration_YYYYMMDD-HHMMSS  # or specify explicitly
+~/resume-migration.sh                                                        # uses most recent migration dir
+MIGRATION_DIR=~/migration_YYYYMMDD-HHMMSS ~/resume-migration.sh              # or specify explicitly
 ```
 
 This backs up the SQLite catalog before resuming and uses `--not-consistent` to allow resuming from a mid-transaction state. The script passes `--split-tables-larger-than` to match `run-migration.sh` — pgcopydb requires catalog consistency, so the resume must use the same split value as the original run.

--- a/pgcopydb-helpers/check-cdc-status.sh
+++ b/pgcopydb-helpers/check-cdc-status.sh
@@ -16,7 +16,7 @@ set +a
 set -u
 
 # --- Configuration ---
-MIGRATION_DIR="${MIGRATION_DIR:-$(ls -dt ~/migration_* 2>/dev/null | head -1 || true)}"
+MIGRATION_DIR="${MIGRATION_DIR:-$(ls -dt ~/migration_*/ 2>/dev/null | head -1 || true)}"
 
 if [ -z "$MIGRATION_DIR" ]; then
     echo "ERROR: No migration directory found"

--- a/pgcopydb-helpers/check-migration-status.sh
+++ b/pgcopydb-helpers/check-migration-status.sh
@@ -27,7 +27,7 @@ source ~/.env
 set +a
 set -u
 
-MIGRATION_DIR=$(ls -dt ~/migration_* 2>/dev/null | head -1)
+MIGRATION_DIR="${MIGRATION_DIR:-$(ls -dt ~/migration_*/ 2>/dev/null | head -1 || true)}"
 if [ -z "$MIGRATION_DIR" ]; then
     echo -e "${RED}✗ No migration directory found${NC}"
     exit 1

--- a/pgcopydb-helpers/resume-migration.sh
+++ b/pgcopydb-helpers/resume-migration.sh
@@ -27,11 +27,7 @@ fi
 # --- loaded ---
 
 # Find the most recent migration directory, or set explicitly
-if [ -n "${1:-}" ]; then
-    MIGRATION_DIR="$1"
-else
-    MIGRATION_DIR=$(ls -dt ~/migration_* 2>/dev/null | head -1)
-fi
+MIGRATION_DIR="${MIGRATION_DIR:-$(ls -dt ~/migration_*/ 2>/dev/null | head -1 || true)}"
 
 if [ -z "$MIGRATION_DIR" ] || [ ! -d "$MIGRATION_DIR" ]; then
     echo "ERROR: No migration directory found. Pass the path as an argument:"

--- a/pgcopydb-helpers/resume-migration.sh
+++ b/pgcopydb-helpers/resume-migration.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
-# Usage: ~/resume-migration.sh [migration_dir]
-# Example: ~/resume-migration.sh ~/migration_YYYYMMDD-HHMMSS
+# Usage: ~/resume-migration.sh
+# Example: MIGRATION_DIR=~/migration_YYYYMMDD-HHMMSS ~/resume-migration.sh
 #
 # Resumes a previously interrupted pgcopydb clone --follow migration.
-# If no directory is given, uses the most recent ~/migration_* directory.
+# Uses MIGRATION_DIR env var if set, otherwise the most recent ~/migration_*/ directory.
 # Backs up the SQLite catalog before resuming.
 #
 # Uses --split-tables-larger-than to match run-migration.sh. pgcopydb

--- a/pgcopydb-helpers/stop_cdc.sh
+++ b/pgcopydb-helpers/stop_cdc.sh
@@ -33,11 +33,7 @@ fi
 ENDPOS_LSN="$1"
 
 # Find the most recent migration directory
-if [ -n "${2:-}" ]; then
-    MIGRATION_DIR="$2"
-else
-    MIGRATION_DIR=$(ls -dt ~/migration_* 2>/dev/null | head -1)
-fi
+MIGRATION_DIR="${MIGRATION_DIR:-$(ls -dt ~/migration_*/ 2>/dev/null | head -1 || true)}"
 
 if [ -z "$MIGRATION_DIR" ] || [ ! -d "$MIGRATION_DIR" ]; then
     echo "ERROR: No migration directory found. Pass the path as second argument:"

--- a/pgcopydb-helpers/stop_cdc.sh
+++ b/pgcopydb-helpers/stop_cdc.sh
@@ -2,10 +2,12 @@
 
 # Usage: ~/stop_cdc.sh <LSN>
 # Example: ~/stop_cdc.sh 41EBA/7C7A1AD8
+# Example: MIGRATION_DIR=~/migration_YYYYMMDD-HHMMSS ~/stop_cdc.sh 41EBA/7C7A1AD8
 #
 # Sets the CDC endpos sentinel so pgcopydb stops streaming
-# after reaching the given LSN. Use the sqlite3 method (more
-# reliable than the pgcopydb CLI sentinel command).
+# after reaching the given LSN. Uses MIGRATION_DIR env var if set,
+# otherwise the most recent ~/migration_*/ directory.
+# Use the sqlite3 method (more reliable than the pgcopydb CLI sentinel command).
 
 
 # --- Load environment ---


### PR DESCRIPTION
The current `ls -dt migration_*` was returning regular file with the same prefix `migration_*`. So added `/` at the end to list only directories.

Also standardized the $MIGRATION_DIR environment variable to use the ternary operator to check if it exists.