### PR TITLE
Add resume-cdc.sh for CDC-only resume

### DIFF
--- a/pgcopydb-helpers/AGENTS.md
+++ b/pgcopydb-helpers/AGENTS.md
@@ -250,6 +250,21 @@ MIGRATION_DIR=~/migration_YYYYMMDD-HHMMSS ~/resume-migration.sh          # speci
 
 ---
 
+#### `resume-cdc.sh`
+
+Resumes only the CDC phase of a previously interrupted migration using `pgcopydb follow`. Does not re-attempt the clone (schema dump/restore, COPY, index creation).
+
+```bash
+~/resume-cdc.sh                                                          # uses most recent migration dir
+MIGRATION_DIR=~/migration_YYYYMMDD-HHMMSS ~/resume-cdc.sh                # specify explicitly
+```
+
+**When to use:** After the initial COPY completed successfully but CDC was interrupted (crash, reboot, connection drop). If you are unsure whether COPY finished, use `resume-migration.sh` instead — it will resume from wherever pgcopydb left off. Logs are written to `resume-cdc-TIMESTAMP.log` in the migration directory.
+
+**Requires:** `PGCOPYDB_SOURCE_PGURI`, `PGCOPYDB_TARGET_PGURI`, existing migration directory with completed COPY
+
+---
+
 #### `target-clean.sh`
 
 Wipes all user objects from the target database for a fresh re-migration. Shows a summary of what will be dropped and prompts for confirmation.
@@ -424,7 +439,8 @@ sqlite3 ~/migration_*/schema/filter.db \
    - Run ~/drop-replication-slots.sh to remove replication artifacts
 
 IF SOMETHING GOES WRONG:
-   - Run ~/resume-migration.sh to resume after a crash
+   - Run ~/resume-migration.sh to resume after a crash (full clone + CDC)
+   - Run ~/resume-cdc.sh to resume only CDC (when COPY already completed)
    - Run ~/target-clean.sh + ~/drop-replication-slots.sh to start over
 ```
 
@@ -436,7 +452,7 @@ All scripts use variables at the top that can be adjusted per migration. See [Cl
 |----------|---------|---------|
 | `TABLE_JOBS` | 16 | run-migration.sh, resume-migration.sh |
 | `INDEX_JOBS` | 12 | run-migration.sh, resume-migration.sh |
-| `FILTER_FILE` | ~/filters.ini | run-migration.sh, resume-migration.sh |
+| `FILTER_FILE` | ~/filters.ini | run-migration.sh, resume-migration.sh, resume-cdc.sh |
 | `--split-tables-larger-than` | 50GB | run-migration.sh, resume-migration.sh |
 
 ## Critical Warnings

--- a/pgcopydb-helpers/README.md
+++ b/pgcopydb-helpers/README.md
@@ -221,6 +221,15 @@ MIGRATION_DIR=~/migration_YYYYMMDD-HHMMSS ~/resume-migration.sh              # o
 
 This backs up the SQLite catalog before resuming and uses `--not-consistent` to allow resuming from a mid-transaction state. The script passes `--split-tables-larger-than` to match `run-migration.sh` — pgcopydb requires catalog consistency, so the resume must use the same split value as the original run.
 
+If the initial COPY completed successfully but CDC was interrupted, you can resume only the CDC phase without re-attempting the clone:
+
+```bash
+~/resume-cdc.sh                                                              # uses most recent migration dir
+MIGRATION_DIR=~/migration_YYYYMMDD-HHMMSS ~/resume-cdc.sh                    # or specify explicitly
+```
+
+This runs `pgcopydb follow` directly (not `clone --follow`), skipping schema dump/restore, COPY, and index creation entirely. Use this when you know the data copy is complete and only CDC streaming needs to restart. Logs are written to `resume-cdc-TIMESTAMP.log` in the migration directory.
+
 To start completely over, wipe the target and clean up replication:
 
 ```bash
@@ -389,7 +398,8 @@ sqlite3 ~/migration_*/schema/filter.db "SELECT COUNT(*) FROM s_depend;"
 | `start-migration-screen.sh` | Migrate | Run the migration in a screen session |
 | `check-migration-status.sh` | Monitor | Migration progress dashboard |
 | `check-cdc-status.sh` | Monitor | CDC replication progress and health |
-| `resume-migration.sh` | Recovery | Resume an interrupted migration |
+| `resume-migration.sh` | Recovery | Resume an interrupted migration (full clone + CDC) |
+| `resume-cdc.sh` | Recovery | Resume only the CDC phase (skips clone) |
 | `target-clean.sh` | Recovery | Wipe target database for re-migration (prompts for confirmation) |
 | `drop-replication-slots.sh` | Cleanup | Remove replication slots and origins |
 | `stop-cdc.sh` | Cutover | Set CDC endpoint via SQLite to initiate cutover |

--- a/pgcopydb-helpers/resume-cdc.sh
+++ b/pgcopydb-helpers/resume-cdc.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Usage: ~/resume-cdc.sh
+# Example: MIGRATION_DIR=~/migration_YYYYMMDD-HHMMSS ~/resume-cdc.sh
+#
+# Resumes only the CDC (change data capture) phase of a previously
+# interrupted migration. Unlike resume-migration.sh, this does NOT
+# re-attempt the clone — it runs pgcopydb follow directly.
+#
+# Use this when the initial COPY completed successfully but CDC was
+# interrupted (crash, reboot, connection drop). Uses MIGRATION_DIR
+# env var if set, otherwise the most recent ~/migration_*/ directory.
+# Backs up the SQLite catalog before resuming.
+#
+set -eo pipefail
+
+# --- Load environment ---
+set +u
+set -a
+source ~/.env
+set +a
+set -u
+
+if [ -z "${PGCOPYDB_SOURCE_PGURI:-}" ] || [ -z "${PGCOPYDB_TARGET_PGURI:-}" ]; then
+    echo "ERROR: PGCOPYDB_SOURCE_PGURI and PGCOPYDB_TARGET_PGURI must be set in ~/.env"
+    exit 1
+fi
+# --- loaded ---
+
+# Find the most recent migration directory, or set explicitly
+MIGRATION_DIR="${MIGRATION_DIR:-$(ls -dt ~/migration_*/ 2>/dev/null | head -1 || true)}"
+
+if [ -z "$MIGRATION_DIR" ] || [ ! -d "$MIGRATION_DIR" ]; then
+    echo "ERROR: No migration directory found. Set the path explicitly:"
+    echo "  MIGRATION_DIR=~/migration_YYYYMMDD-HHMMSS $0"
+    exit 1
+fi
+
+echo "Resuming CDC in: $MIGRATION_DIR"
+
+LOGFILE=$MIGRATION_DIR/resume-cdc-$(date +%Y%m%d-%H%M%S).log
+FILTER_FILE=~/filters.ini
+
+cd "$MIGRATION_DIR"
+ulimit -c unlimited
+echo "$MIGRATION_DIR/core.%e.%p" | sudo tee /proc/sys/kernel/core_pattern
+
+# Back up SQLite catalog before resume
+cp "$MIGRATION_DIR/schema/source.db" "$MIGRATION_DIR/schema/source.db.bak.$(date +%Y%m%d-%H%M%S)"
+
+{
+    echo ""
+    echo "=========================================="
+    echo "Resuming CDC (follow only) at $(date)"
+    echo "Migration dir: $MIGRATION_DIR"
+    echo "=========================================="
+
+    /usr/lib/postgresql/17/bin/pgcopydb follow \
+        --plugin wal2json \
+        --resume \
+        --not-consistent \
+        --verbose \
+        --source "$PGCOPYDB_SOURCE_PGURI" \
+        --target "$PGCOPYDB_TARGET_PGURI" \
+        --filter "$FILTER_FILE" \
+        --dir "$MIGRATION_DIR"
+
+    EXIT_CODE=$?
+    echo "CDC resume completed at $(date) - Exit code: $EXIT_CODE"
+    exit "$EXIT_CODE"
+} 2>&1 | tee -a "$LOGFILE"

--- a/pgcopydb-helpers/resume-cdc.sh
+++ b/pgcopydb-helpers/resume-cdc.sh
@@ -45,6 +45,12 @@ cd "$MIGRATION_DIR"
 ulimit -c unlimited
 echo "$MIGRATION_DIR/core.%e.%p" | sudo tee /proc/sys/kernel/core_pattern
 
+PGCOPYDB_BIN=$(command -v pgcopydb 2>/dev/null || true)
+if [ -z "$PGCOPYDB_BIN" ]; then
+    echo "ERROR: pgcopydb not found on PATH"
+    exit 1
+fi
+
 # Back up SQLite catalog before resume
 cp "$MIGRATION_DIR/schema/source.db" "$MIGRATION_DIR/schema/source.db.bak.$(date +%Y%m%d-%H%M%S)"
 
@@ -55,7 +61,7 @@ cp "$MIGRATION_DIR/schema/source.db" "$MIGRATION_DIR/schema/source.db.bak.$(date
     echo "Migration dir: $MIGRATION_DIR"
     echo "=========================================="
 
-    /usr/lib/postgresql/17/bin/pgcopydb follow \
+    "$PGCOPYDB_BIN" follow \
         --plugin wal2json \
         --resume \
         --not-consistent \

--- a/pgcopydb-helpers/resume-cdc.sh
+++ b/pgcopydb-helpers/resume-cdc.sh
@@ -40,6 +40,7 @@ echo "Resuming CDC in: $MIGRATION_DIR"
 
 LOGFILE=$MIGRATION_DIR/resume-cdc-$(date +%Y%m%d-%H%M%S).log
 FILTER_FILE=~/filters.ini
+TABLE_JOBS=16
 
 cd "$MIGRATION_DIR"
 ulimit -c unlimited
@@ -69,6 +70,8 @@ cp "$MIGRATION_DIR/schema/source.db" "$MIGRATION_DIR/schema/source.db.bak.$(date
         --source "$PGCOPYDB_SOURCE_PGURI" \
         --target "$PGCOPYDB_TARGET_PGURI" \
         --filter "$FILTER_FILE" \
+        --split-tables-larger-than 50GB \
+        --split-max-parts "$TABLE_JOBS" \
         --dir "$MIGRATION_DIR"
 
     EXIT_CODE=$?


### PR DESCRIPTION
## Summary

- Adds `resume-cdc.sh` which uses `pgcopydb follow` directly to resume only the CDC streaming phase, without re-attempting the clone (schema dump/restore, COPY, index creation)
- Use when the initial data copy completed successfully but CDC was interrupted (crash, reboot, connection drop)
- Logs to `resume-cdc-TIMESTAMP.log` in the migration directory, which `check-cdc-status.sh` already picks up via its `resume-*.log` glob

## Test plan

- [ ] Deploy to a migration instance and verify `resume-cdc.sh` starts CDC streaming from the sentinel's last position
- [ ] Confirm `check-cdc-status.sh` reads the `resume-cdc-*.log` file
- [ ] Verify the script errors cleanly when no migration directory exists