### PR TITLE
fix cfn template: force public IP and remove missing configset

### DIFF
--- a/pgcopydb-templates/aws-cloudformation/pgcopydb-migration-instance.yaml
+++ b/pgcopydb-templates/aws-cloudformation/pgcopydb-migration-instance.yaml
@@ -173,7 +173,6 @@ Resources:
             - setup_cfn
             - install_packages
             - configure_system
-            - create_directories
             - verify_installation
         setup_cfn:
           files:
@@ -328,9 +327,12 @@ Resources:
       InstanceType: !Ref InstanceType
       KeyName: !If [HasKeyPair, !Ref KeyPairName, !Ref 'AWS::NoValue']
       IamInstanceProfile: !Ref InstanceProfile
-      SubnetId: !Ref SubnetId
-      SecurityGroupIds:
-        - !Ref SecurityGroup
+      NetworkInterfaces:
+        - AssociatePublicIpAddress: true
+          DeviceIndex: '0'
+          SubnetId: !Ref SubnetId
+          GroupSet:
+            - !Ref SecurityGroup
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
@@ -390,7 +392,8 @@ Outputs:
     Value: !Ref SecurityGroup
 
   SSHCommand:
-    Description: SSH connection command
+    Condition: HasKeyPair
+    Description: SSH connection command (only shown when Key Pair is provided)
     Value: !Sub 'ssh -i /path/to/${KeyPairName}.pem ubuntu@${Instance.PublicIp}'
 
   EC2InstanceConnectCommand:


### PR DESCRIPTION
1. **create_directories** removed from configSets — it had no matching config block, causing cfn-init to fail every time and rollback the stack.
2. **NetworkInterfaces** with **AssociatePublicIpAddress: true** — replaces the top-level **SubnetId/SecurityGroupIds** so the instance always gets a public IP regardless of the subnet's auto-assign setting. This also ensures internet access for the entire setup script (apt, git clone, AWS CLI download, etc.) works unconditionally.
3. **SSHCommand** output marked **Condition: HasKeyPair** — was always rendered even when no key pair was supplied, producing a meaningless output with an empty path. 