### PR TITLE
Feature/preflight extension check

### DIFF
--- a/pgcopydb-helpers/AGENTS.md
+++ b/pgcopydb-helpers/AGENTS.md
@@ -86,7 +86,7 @@ Validates all migration prerequisites before starting `pgcopydb clone --follow`.
 
 **Checks performed:**
 - **Source:** connectivity, `wal_level = logical`, replication permission (REPLICATION, SUPERUSER, or rds_replication), available replication slots, available WAL senders, leftover pgcopydb slot, FOR ALL TABLES publications, `wal_sender_timeout`, prepared transactions
-- **Target:** connectivity, replication permission, leftover pgcopydb schema
+- **Target:** connectivity, replication permission, leftover pgcopydb schema, extension compatibility (FAILs if any source extension is absent on target — add missing ones to `[exclude-extension]` in `filters.ini` if the exclusion is intentional)
 - **Instance:** `~/filters.ini` exists, pgcopydb binary on PATH
 
 **When to use:** Before every migration attempt. Run after setting up `~/.env` and `~/filters.ini` but before `~/start-migration-screen.sh`. Fix all FAILs before proceeding. Review WARNs — especially `wal_sender_timeout` (should be `0` for large migrations) and leftover state from previous attempts.

--- a/pgcopydb-helpers/README.md
+++ b/pgcopydb-helpers/README.md
@@ -125,7 +125,7 @@ Before starting the migration, compare PostgreSQL parameters between source and 
 ~/compare-pg-params.sh
 ```
 
-Run the preflight check to validate that both databases and the migration instance are ready. This checks connectivity, WAL level, replication permissions, available slots/senders, conflicting publications, and local prerequisites:
+Run the preflight check to validate that both databases and the migration instance are ready. This checks connectivity, WAL level, replication permissions, available slots/senders, conflicting publications, extension compatibility (source extensions present on target), and local prerequisites:
 
 ```bash
 ~/preflight-check.sh
@@ -391,7 +391,7 @@ sqlite3 ~/migration_*/schema/filter.db "SELECT COUNT(*) FROM s_depend;"
 | Script | Phase | Description |
 |--------|-------|-------------|
 | `compare-pg-params.sh` | Prepare | Compare PostgreSQL parameters between source and target |
-| `preflight-check.sh` | Prepare | Validate migration prerequisites (connectivity, WAL level, permissions, slots) |
+| `preflight-check.sh` | Prepare | Validate migration prerequisites (connectivity, WAL level, permissions, slots, extension compatibility) |
 | `fix-replica-identity.sh` | Prepare | Set REPLICA IDENTITY FULL on tables without primary keys |
 | `filters.ini` | Prepare | pgcopydb filter configuration |
 | `run-migration.sh` | Migrate | Start a pgcopydb clone --follow migration |

--- a/pgcopydb-helpers/preflight-check.sh
+++ b/pgcopydb-helpers/preflight-check.sh
@@ -249,23 +249,31 @@ if [ -n "$TGT_VER" ]; then
     fi
 
     # 14. Extension compatibility
+    FILTER_EXCLUDED_EXTS=""
+    if [ -f ~/filters.ini ]; then
+        FILTER_EXCLUDED_EXTS=$(awk '/^\[exclude-extension\]/{found=1; next} /^\[/{found=0} found && /[^[:space:]]/{gsub(/^[[:space:]]+|[[:space:]]+$/, ""); print}' ~/filters.ini)
+    fi
+
     SRC_EXTS=$(src_query "SELECT extname FROM pg_extension ORDER BY extname;")
     TGT_EXTS=$(tgt_query "SELECT extname FROM pg_extension ORDER BY extname;")
     MISSING_EXTS=""
-    SRC_EXT_COUNT=0
+    CHECKED_COUNT=0
     while IFS= read -r ext; do
         [ -z "$ext" ] && continue
-        SRC_EXT_COUNT=$((SRC_EXT_COUNT + 1))
+        if printf '%s\n' "$FILTER_EXCLUDED_EXTS" | grep -qx "$ext"; then
+            continue
+        fi
+        CHECKED_COUNT=$((CHECKED_COUNT + 1))
         if ! printf '%s\n' "$TGT_EXTS" | grep -qx "$ext"; then
             MISSING_EXTS="${MISSING_EXTS:+$MISSING_EXTS, }$ext"
         fi
     done <<< "$SRC_EXTS"
     if [ -n "$MISSING_EXTS" ]; then
         fail "Extensions" "missing on target: $MISSING_EXTS"
-    elif [ "$SRC_EXT_COUNT" -gt 0 ]; then
-        pass "Extensions" "all $SRC_EXT_COUNT source extension(s) present on target"
+    elif [ "$CHECKED_COUNT" -gt 0 ]; then
+        pass "Extensions" "all $CHECKED_COUNT extension(s) present on target"
     else
-        pass "Extensions" "no extensions on source"
+        pass "Extensions" "no extensions to check"
     fi
 fi
 

--- a/pgcopydb-helpers/preflight-check.sh
+++ b/pgcopydb-helpers/preflight-check.sh
@@ -247,6 +247,26 @@ if [ -n "$TGT_VER" ]; then
     else
         pass "Existing pgcopydb schema" "none"
     fi
+
+    # 14. Extension compatibility
+    SRC_EXTS=$(src_query "SELECT extname FROM pg_extension ORDER BY extname;")
+    TGT_EXTS=$(tgt_query "SELECT extname FROM pg_extension ORDER BY extname;")
+    MISSING_EXTS=""
+    SRC_EXT_COUNT=0
+    while IFS= read -r ext; do
+        [ -z "$ext" ] && continue
+        SRC_EXT_COUNT=$((SRC_EXT_COUNT + 1))
+        if ! printf '%s\n' "$TGT_EXTS" | grep -qx "$ext"; then
+            MISSING_EXTS="${MISSING_EXTS:+$MISSING_EXTS, }$ext"
+        fi
+    done <<< "$SRC_EXTS"
+    if [ -n "$MISSING_EXTS" ]; then
+        fail "Extensions" "missing on target: $MISSING_EXTS"
+    elif [ "$SRC_EXT_COUNT" -gt 0 ]; then
+        pass "Extensions" "all $SRC_EXT_COUNT source extension(s) present on target"
+    else
+        pass "Extensions" "no extensions on source"
+    fi
 fi
 
 # ── MIGRATION INSTANCE ─────────────────────────────────────────────

--- a/pgcopydb-helpers/preflight-check.sh
+++ b/pgcopydb-helpers/preflight-check.sh
@@ -255,7 +255,7 @@ if [ -n "$TGT_VER" ]; then
     fi
 
     SRC_EXTS=$(src_query "SELECT extname FROM pg_extension ORDER BY extname;")
-    TGT_EXTS=$(tgt_query "SELECT extname FROM pg_extension ORDER BY extname;")
+    TGT_AVAIL_EXTS=$(tgt_query "SELECT name FROM pg_available_extensions ORDER BY name;")
     MISSING_EXTS=""
     CHECKED_COUNT=0
     while IFS= read -r ext; do
@@ -264,14 +264,14 @@ if [ -n "$TGT_VER" ]; then
             continue
         fi
         CHECKED_COUNT=$((CHECKED_COUNT + 1))
-        if ! printf '%s\n' "$TGT_EXTS" | grep -qx "$ext"; then
+        if ! printf '%s\n' "$TGT_AVAIL_EXTS" | grep -qx "$ext"; then
             MISSING_EXTS="${MISSING_EXTS:+$MISSING_EXTS, }$ext"
         fi
     done <<< "$SRC_EXTS"
     if [ -n "$MISSING_EXTS" ]; then
-        fail "Extensions" "missing on target: $MISSING_EXTS"
+        fail "Extensions" "not available on target: $MISSING_EXTS"
     elif [ "$CHECKED_COUNT" -gt 0 ]; then
-        pass "Extensions" "all $CHECKED_COUNT extension(s) present on target"
+        pass "Extensions" "all $CHECKED_COUNT source extension(s) available on target"
     else
         pass "Extensions" "no extensions to check"
     fi


### PR DESCRIPTION
1. **Extension compatibility check** : compares source vs target extensions, fails if target is missing any
2. **filters.ini integration** : reads [exclude-extension] from ~/filters.ini and skips those **extensions** from the check; also added a separate check that ~/filters.ini exists