### PR TITLE
README + AGENTS: note BYPASSRLS requirement for Supabase migrations

### DIFF
--- a/pgcopydb-helpers/AGENTS.md
+++ b/pgcopydb-helpers/AGENTS.md
@@ -146,6 +146,24 @@ trigger_to_skip
 
 ---
 
+#### Source-Specific: Supabase RLS
+
+Supabase source databases typically have Row-Level Security on application tables. Without `BYPASSRLS`, the migration user reads zero rows from RLS-protected tables and the migration silently produces an incomplete target. Detect and fix on the source:
+
+```sql
+-- Find RLS-protected tables (run per schema)
+SELECT tablename, rowsecurity
+FROM pg_tables
+WHERE schemaname = '<schema_name>' AND rowsecurity = true;
+
+-- Fix (requires superuser on source)
+ALTER ROLE migration_user BYPASSRLS;
+```
+
+**When to flag:** Any migration from Supabase, or any source where `pg_tables.rowsecurity = true` exists in user schemas.
+
+---
+
 ### Running a Migration
 
 #### `run-migration.sh`

--- a/pgcopydb-helpers/README.md
+++ b/pgcopydb-helpers/README.md
@@ -62,6 +62,21 @@ After running `fix-replica-identity.sh`, revoke the membership:
 REVOKE <owner_role> FROM migration_user;
 ```
 
+**Row-Level Security (RLS) — Supabase and other RLS-heavy sources:** If any source tables have RLS enabled, `migration_user` must bypass it — otherwise pgcopydb sees zero rows for those tables and the target ends up incomplete with no error. Check which tables use RLS (run per schema):
+
+```sql
+SELECT tablename, rowsecurity
+FROM pg_tables
+WHERE schemaname = '<schema_name>'
+  AND rowsecurity = true;
+```
+
+If any tables are returned, grant the bypass on the source (requires superuser):
+
+```sql
+ALTER ROLE migration_user BYPASSRLS;
+```
+
 **Logical replication (CDC only):** Logical replication must be enabled on the source before starting a `--follow` migration. How to enable it depends on your platform:
 
 - **Amazon RDS / Aurora:** Set `rds.logical_replication = 1` in the [parameter group](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html) and reboot the instance. If you are using a custom parameter group, make sure it is associated with your instance. This change requires a reboot — it cannot be applied dynamically.


### PR DESCRIPTION
Supabase source databases typically have Row-Level Security on application tables. Without `BYPASSRLS`, the migration user reads zero rows from RLS-protected tables and the migration silently produces an incomplete target. 
