### PR TITLE
Update pgcopydb templates to PostgreSQL 18

### DIFF
--- a/pgcopydb-templates/README.md
+++ b/pgcopydb-templates/README.md
@@ -14,7 +14,7 @@ All three templates produce an equivalent migration instance — choose based on
 
 ## What Gets Provisioned
 
-- A compute instance with pgcopydb and PostgreSQL 17 client tools
+- A compute instance with pgcopydb and PostgreSQL 18 client tools
 - An attached data volume for migration working data
 - Network and access configuration (security group/firewall rule, IAM/SSH via SSM or IAP)
 - Migration helper scripts from this repo deployed to `/home/ubuntu/`

--- a/pgcopydb-templates/aws-cloudformation/pgcopydb-migration-instance.yaml
+++ b/pgcopydb-templates/aws-cloudformation/pgcopydb-migration-instance.yaml
@@ -268,8 +268,8 @@ Resources:
             04_install_postgresql:
               command: |
                 export DEBIAN_FRONTEND=noninteractive
-                # Install PostgreSQL 17 client and build dependencies
-                apt-get install -y postgresql-client-17 postgresql-17 postgresql-server-dev-17
+                # Install PostgreSQL 18 client and build dependencies
+                apt-get install -y postgresql-client-18 postgresql-18 postgresql-server-dev-18
             05_install_build_tools:
               command: |
                 export DEBIAN_FRONTEND=noninteractive
@@ -295,7 +295,7 @@ Resources:
                 cd /tmp
                 git clone --branch v0.18.0 https://github.com/planetscale/pgcopydb.git
                 cd pgcopydb
-                export PATH=/usr/lib/postgresql/17/bin:$PATH
+                export PATH=/usr/lib/postgresql/18/bin:$PATH
                 make clean || true
                 make
                 make install
@@ -338,7 +338,7 @@ Resources:
               group: root
             /etc/profile.d/pgcopydb.sh:
               content: |
-                export PATH=/usr/lib/postgresql/17/bin:$PATH
+                export PATH=/usr/lib/postgresql/18/bin:$PATH
                 alias pgcopydb-version='pgcopydb --version'
                 alias psql-version='psql --version'
                 alias check-planetscale='nc -zv app.connect.psdb.cloud 443 2>&1 | grep succeeded'
@@ -373,7 +373,7 @@ Resources:
             01_log_versions:
               command: |
                 echo "=== Installation verification ===" >> /var/log/cfn-init-verification.log
-                export PATH=/usr/lib/postgresql/17/bin:$PATH
+                export PATH=/usr/lib/postgresql/18/bin:$PATH
                 pgcopydb --version >> /var/log/cfn-init-verification.log 2>&1 || echo "pgcopydb installation failed" >> /var/log/cfn-init-verification.log
                 psql --version >> /var/log/cfn-init-verification.log 2>&1 || echo "PostgreSQL client installation failed" >> /var/log/cfn-init-verification.log
                 aws --version >> /var/log/cfn-init-verification.log 2>&1 || echo "AWS CLI installation failed" >> /var/log/cfn-init-verification.log

--- a/pgcopydb-templates/aws-terraform/user-data.sh
+++ b/pgcopydb-templates/aws-terraform/user-data.sh
@@ -20,13 +20,13 @@ apt-get update -y
 apt-get install -y wget gnupg2 lsb-release curl unzip ca-certificates netcat-openbsd sqlite3
 
 # =============================================================================
-# Install PostgreSQL 17
+# Install PostgreSQL 18
 # =============================================================================
-echo "Installing PostgreSQL 17..."
+echo "Installing PostgreSQL 18..."
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql-keyring.gpg
 echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 apt-get update
-apt-get install -y postgresql-client-17 postgresql-17 postgresql-server-dev-17
+apt-get install -y postgresql-client-18 postgresql-18 postgresql-server-dev-18
 
 # =============================================================================
 # Install Build Tools
@@ -56,7 +56,7 @@ echo "Building pgcopydb from source..."
 cd /tmp
 git clone --branch v0.18.0 https://github.com/planetscale/pgcopydb.git
 cd pgcopydb
-export PATH=/usr/lib/postgresql/17/bin:$PATH
+export PATH=/usr/lib/postgresql/18/bin:$PATH
 make clean || true
 make
 make install
@@ -105,7 +105,7 @@ sysctl -p /etc/sysctl.d/99-pgcopydb.conf
 
 # PATH configuration
 cat > /etc/profile.d/pgcopydb.sh << 'PROFILE_EOF'
-export PATH=/usr/lib/postgresql/17/bin:$PATH
+export PATH=/usr/lib/postgresql/18/bin:$PATH
 alias pgcopydb-version='pgcopydb --version'
 alias psql-version='psql --version'
 alias check-planetscale='nc -zv app.connect.psdb.cloud 443 2>&1 | grep succeeded'
@@ -139,7 +139,7 @@ chmod +x /home/ubuntu/*.sh
 # Verify Installation
 # =============================================================================
 echo "=== Installation verification ===" >> /var/log/user-data-verification.log
-export PATH=/usr/lib/postgresql/17/bin:$PATH
+export PATH=/usr/lib/postgresql/18/bin:$PATH
 pgcopydb --version >> /var/log/user-data-verification.log 2>&1 || echo "pgcopydb installation failed" >> /var/log/user-data-verification.log
 psql --version >> /var/log/user-data-verification.log 2>&1 || echo "PostgreSQL client installation failed" >> /var/log/user-data-verification.log
 aws --version >> /var/log/user-data-verification.log 2>&1 || echo "AWS CLI installation failed" >> /var/log/user-data-verification.log

--- a/pgcopydb-templates/gcp-terraform/startup-script.sh
+++ b/pgcopydb-templates/gcp-terraform/startup-script.sh
@@ -23,13 +23,13 @@ apt-get update -y
 apt-get install -y wget gnupg2 lsb-release curl unzip ca-certificates netcat-openbsd sqlite3
 
 # =============================================================================
-# Install PostgreSQL 17
+# Install PostgreSQL 18
 # =============================================================================
-echo "Installing PostgreSQL 17..."
+echo "Installing PostgreSQL 18..."
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql-keyring.gpg
 echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 apt-get update
-apt-get install -y postgresql-client-17 postgresql-17 postgresql-server-dev-17
+apt-get install -y postgresql-client-18 postgresql-18 postgresql-server-dev-18
 
 # =============================================================================
 # Install Build Tools
@@ -59,7 +59,7 @@ echo "Building pgcopydb from source..."
 cd /tmp
 git clone --branch v0.18.0 https://github.com/planetscale/pgcopydb.git
 cd pgcopydb
-export PATH=/usr/lib/postgresql/17/bin:$PATH
+export PATH=/usr/lib/postgresql/18/bin:$PATH
 make clean || true
 make
 make install
@@ -89,7 +89,7 @@ sysctl -p /etc/sysctl.d/99-pgcopydb.conf
 
 # PATH configuration
 cat > /etc/profile.d/pgcopydb.sh << 'PROFILE_EOF'
-export PATH=/usr/lib/postgresql/17/bin:$PATH
+export PATH=/usr/lib/postgresql/18/bin:$PATH
 alias pgcopydb-version='pgcopydb --version'
 alias psql-version='psql --version'
 alias check-planetscale='nc -zv app.connect.psdb.cloud 443 2>&1 | grep succeeded'


### PR DESCRIPTION
## Summary

Bumps the pgcopydb migration instance templates from PostgreSQL 17 to 18 across all three providers:

- **AWS CloudFormation** (`aws-cloudformation/pgcopydb-migration-instance.yaml`)
- **AWS Terraform** (`aws-terraform/user-data.sh`)
- **GCP Terraform** (`gcp-terraform/startup-script.sh`)

### Changes

- Package install: `postgresql-client-18 postgresql-18 postgresql-server-dev-18`
- Build + runtime `PATH`: `/usr/lib/postgresql/18/bin`
- Install section headings / echo messages updated to PostgreSQL 18
- `README.md` "What Gets Provisioned" updated to PostgreSQL 18 client tools

Mirrors the corresponding change in the Liftoff Migration Reviewer template generators (planetscale/liftoff-migration-reviewer#276).