### PR TITLE
Update pgcopydb templates to v0.19.0

### DIFF
--- a/pgcopydb-templates/aws-cloudformation/pgcopydb-migration-instance.yaml
+++ b/pgcopydb-templates/aws-cloudformation/pgcopydb-migration-instance.yaml
@@ -294,7 +294,7 @@ Resources:
             06_build_pgcopydb:
               command: |
                 cd /tmp
-                git clone --branch v0.18.0 https://github.com/planetscale/pgcopydb.git
+                git clone --branch v0.19.0 https://github.com/planetscale/pgcopydb.git
                 cd pgcopydb
                 export PATH=/usr/lib/postgresql/18/bin:$PATH
                 make clean || true

--- a/pgcopydb-templates/aws-terraform/user-data.sh
+++ b/pgcopydb-templates/aws-terraform/user-data.sh
@@ -55,7 +55,7 @@ apt-get install -y \
 # =============================================================================
 echo "Building pgcopydb from source..."
 cd /tmp
-git clone --branch v0.18.0 https://github.com/planetscale/pgcopydb.git
+git clone --branch v0.19.0 https://github.com/planetscale/pgcopydb.git
 cd pgcopydb
 export PATH=/usr/lib/postgresql/18/bin:$PATH
 make clean || true

--- a/pgcopydb-templates/gcp-terraform/startup-script.sh
+++ b/pgcopydb-templates/gcp-terraform/startup-script.sh
@@ -58,7 +58,7 @@ apt-get install -y \
 # =============================================================================
 echo "Building pgcopydb from source..."
 cd /tmp
-git clone --branch v0.18.0 https://github.com/planetscale/pgcopydb.git
+git clone --branch v0.19.0 https://github.com/planetscale/pgcopydb.git
 cd pgcopydb
 export PATH=/usr/lib/postgresql/18/bin:$PATH
 make clean || true


### PR DESCRIPTION
Bumps the pgcopydb clone branch from v0.18.0 to v0.19.0 in the migration instance provisioning templates.

## Changes
- `aws-terraform/user-data.sh`
- `gcp-terraform/startup-script.sh`
- `aws-cloudformation/pgcopydb-migration-instance.yaml`

Each template clones `--branch v0.19.0` from the PlanetScale pgcopydb fork during the build step.