### PR TITLE
Auto-detect pgcopydb binary instead of hardcoding version path

### DIFF
--- a/pgcopydb-helpers/preflight-check.sh
+++ b/pgcopydb-helpers/preflight-check.sh
@@ -404,13 +404,13 @@ fi
 
 # 15. pgcopydb binary
 PGCOPYDB_BIN=$(command -v pgcopydb 2>/dev/null || echo "")
-if [ -z "$PGCOPYDB_BIN" ] && [ -x /usr/lib/postgresql/17/bin/pgcopydb ]; then
-    PGCOPYDB_BIN="/usr/lib/postgresql/17/bin/pgcopydb"
+if [ -z "$PGCOPYDB_BIN" ]; then
+    PGCOPYDB_BIN=$(ls -d /usr/lib/postgresql/*/bin/pgcopydb 2>/dev/null | sort -rV | head -n1)
 fi
-if [ -n "$PGCOPYDB_BIN" ]; then
+if [ -n "$PGCOPYDB_BIN" ] && [ -x "$PGCOPYDB_BIN" ]; then
     pass "pgcopydb binary" "$PGCOPYDB_BIN"
 else
-    fail "pgcopydb binary" "not found on PATH or /usr/lib/postgresql/17/bin/"
+    fail "pgcopydb binary" "not found on PATH or under /usr/lib/postgresql/*/bin/"
 fi
 
 # ── Summary ────────────────────────────────────────────────────────

--- a/pgcopydb-helpers/preflight-check.sh
+++ b/pgcopydb-helpers/preflight-check.sh
@@ -405,7 +405,7 @@ fi
 # 15. pgcopydb binary
 PGCOPYDB_BIN=$(command -v pgcopydb 2>/dev/null || echo "")
 if [ -z "$PGCOPYDB_BIN" ]; then
-    PGCOPYDB_BIN=$(ls -d /usr/lib/postgresql/*/bin/pgcopydb 2>/dev/null | sort -rV | head -n1)
+    PGCOPYDB_BIN=$(ls -d /usr/lib/postgresql/*/bin/pgcopydb 2>/dev/null | sort -rV | head -n1 || true)
 fi
 if [ -n "$PGCOPYDB_BIN" ] && [ -x "$PGCOPYDB_BIN" ]; then
     pass "pgcopydb binary" "$PGCOPYDB_BIN"

--- a/pgcopydb-helpers/resume-cdc.sh
+++ b/pgcopydb-helpers/resume-cdc.sh
@@ -46,11 +46,19 @@ cd "$MIGRATION_DIR"
 ulimit -c unlimited
 echo "$MIGRATION_DIR/core.%e.%p" | sudo tee /proc/sys/kernel/core_pattern
 
-PGCOPYDB_BIN=$(command -v pgcopydb 2>/dev/null || true)
-if [ -z "$PGCOPYDB_BIN" ]; then
-    echo "ERROR: pgcopydb not found on PATH"
-    exit 1
-fi
+# --- Locate pgcopydb: prefer PATH, else highest-versioned PG install ---
+find_pgcopydb() {
+    local bin
+    if bin=$(command -v pgcopydb 2>/dev/null); then
+        echo "$bin"; return 0
+    fi
+    bin=$(ls -d /usr/lib/postgresql/*/bin/pgcopydb 2>/dev/null | sort -rV | head -n1)
+    if [ -n "$bin" ] && [ -x "$bin" ]; then
+        echo "$bin"; return 0
+    fi
+    return 1
+}
+PGCOPYDB_BIN=$(find_pgcopydb) || { echo "ERROR: pgcopydb not found on PATH or under /usr/lib/postgresql/*/bin" >&2; exit 1; }
 
 # Back up SQLite catalog before resume
 cp "$MIGRATION_DIR/schema/source.db" "$MIGRATION_DIR/schema/source.db.bak.$(date +%Y%m%d-%H%M%S)"

--- a/pgcopydb-helpers/resume-cdc.sh
+++ b/pgcopydb-helpers/resume-cdc.sh
@@ -52,7 +52,7 @@ find_pgcopydb() {
     if bin=$(command -v pgcopydb 2>/dev/null); then
         echo "$bin"; return 0
     fi
-    bin=$(ls -d /usr/lib/postgresql/*/bin/pgcopydb 2>/dev/null | sort -rV | head -n1)
+    bin=$(ls -d /usr/lib/postgresql/*/bin/pgcopydb 2>/dev/null | sort -rV | head -n1 || true)
     if [ -n "$bin" ] && [ -x "$bin" ]; then
         echo "$bin"; return 0
     fi

--- a/pgcopydb-helpers/resume-migration.sh
+++ b/pgcopydb-helpers/resume-migration.sh
@@ -26,6 +26,21 @@ if [ -z "${PGCOPYDB_SOURCE_PGURI:-}" ] || [ -z "${PGCOPYDB_TARGET_PGURI:-}" ]; t
 fi
 # --- loaded ---
 
+# --- Locate pgcopydb: prefer PATH, else highest-versioned PG install ---
+find_pgcopydb() {
+    local bin
+    if bin=$(command -v pgcopydb 2>/dev/null); then
+        echo "$bin"; return 0
+    fi
+    bin=$(ls -d /usr/lib/postgresql/*/bin/pgcopydb 2>/dev/null | sort -rV | head -n1)
+    if [ -n "$bin" ] && [ -x "$bin" ]; then
+        echo "$bin"; return 0
+    fi
+    return 1
+}
+PGCOPYDB_BIN=$(find_pgcopydb) || { echo "ERROR: pgcopydb not found on PATH or under /usr/lib/postgresql/*/bin" >&2; exit 1; }
+# --- located ---
+
 # Find the most recent migration directory, or set explicitly
 MIGRATION_DIR="${MIGRATION_DIR:-$(ls -dt ~/migration_*/ 2>/dev/null | head -1 || true)}"
 
@@ -56,7 +71,7 @@ cp "$MIGRATION_DIR/schema/source.db" "$MIGRATION_DIR/schema/source.db.bak.$(date
     echo "Migration dir: $MIGRATION_DIR"
     echo "=========================================="
 
-    /usr/lib/postgresql/17/bin/pgcopydb clone \
+    "$PGCOPYDB_BIN" clone \
         --follow \
         --plugin wal2json \
         --resume \

--- a/pgcopydb-helpers/resume-migration.sh
+++ b/pgcopydb-helpers/resume-migration.sh
@@ -32,7 +32,7 @@ find_pgcopydb() {
     if bin=$(command -v pgcopydb 2>/dev/null); then
         echo "$bin"; return 0
     fi
-    bin=$(ls -d /usr/lib/postgresql/*/bin/pgcopydb 2>/dev/null | sort -rV | head -n1)
+    bin=$(ls -d /usr/lib/postgresql/*/bin/pgcopydb 2>/dev/null | sort -rV | head -n1 || true)
     if [ -n "$bin" ] && [ -x "$bin" ]; then
         echo "$bin"; return 0
     fi

--- a/pgcopydb-helpers/run-migration.sh
+++ b/pgcopydb-helpers/run-migration.sh
@@ -21,6 +21,21 @@ if [ -z "${PGCOPYDB_SOURCE_PGURI:-}" ] || [ -z "${PGCOPYDB_TARGET_PGURI:-}" ]; t
 fi
 # --- loaded ---
 
+# --- Locate pgcopydb: prefer PATH, else highest-versioned PG install ---
+find_pgcopydb() {
+    local bin
+    if bin=$(command -v pgcopydb 2>/dev/null); then
+        echo "$bin"; return 0
+    fi
+    bin=$(ls -d /usr/lib/postgresql/*/bin/pgcopydb 2>/dev/null | sort -rV | head -n1)
+    if [ -n "$bin" ] && [ -x "$bin" ]; then
+        echo "$bin"; return 0
+    fi
+    return 1
+}
+PGCOPYDB_BIN=$(find_pgcopydb) || { echo "ERROR: pgcopydb not found on PATH or under /usr/lib/postgresql/*/bin" >&2; exit 1; }
+# --- located ---
+
 MIGRATION_DIR=~/migration_$(date +%Y%m%d-%H%M%S)
 LOGFILE=$MIGRATION_DIR/migration.log
 FILTER_FILE=~/filters.ini
@@ -38,7 +53,7 @@ echo "$MIGRATION_DIR/core.%e.%p" | sudo tee /proc/sys/kernel/core_pattern
     echo "Starting clone --follow at $(date)"
     echo "=========================================="
 
-    /usr/lib/postgresql/17/bin/pgcopydb clone \
+    "$PGCOPYDB_BIN" clone \
         --follow \
         --plugin wal2json \
         --verbose \

--- a/pgcopydb-helpers/run-migration.sh
+++ b/pgcopydb-helpers/run-migration.sh
@@ -27,7 +27,7 @@ find_pgcopydb() {
     if bin=$(command -v pgcopydb 2>/dev/null); then
         echo "$bin"; return 0
     fi
-    bin=$(ls -d /usr/lib/postgresql/*/bin/pgcopydb 2>/dev/null | sort -rV | head -n1)
+    bin=$(ls -d /usr/lib/postgresql/*/bin/pgcopydb 2>/dev/null | sort -rV | head -n1 || true)
     if [ -n "$bin" ] && [ -x "$bin" ]; then
         echo "$bin"; return 0
     fi


### PR DESCRIPTION
## What

Replace the hardcoded `/usr/lib/postgresql/NN/bin/pgcopydb` path with a single detection helper across the migration scripts.

Before this change there were three inconsistent patterns for locating the binary:

| Script | Old approach |
|---|---|
| `run-migration.sh`, `resume-migration.sh` | hardcoded versioned path |
| `resume-cdc.sh` | `command -v pgcopydb` only (failed if not on `PATH`) |
| `preflight-check.sh` | `command -v` + hardcoded-version fallback |

## How

Each script now resolves the binary the same way:

1. Prefer `pgcopydb` on `PATH`.
2. Otherwise glob `/usr/lib/postgresql/*/bin/pgcopydb`, sort by version (`sort -rV`), and pick the highest.
3. Fail with a clear error if neither resolves.

PostgreSQL major-version bumps (e.g. 18 → 19) no longer require editing these scripts.

## Testing

- `bash -n` passes on all four scripts.
- Verified the version-glob selects the highest install (`18` over `9`/`16`/`17`) — `sort -rV` ranks numerically, not lexically.
- Confirmed no hardcoded `postgresql/NN/bin` paths remain.