### PR TITLE
Make verify-migration.sh aware of filters.ini

### DIFF
--- a/pgcopydb-helpers/AGENTS.md
+++ b/pgcopydb-helpers/AGENTS.md
@@ -60,13 +60,12 @@ Verifies that all data was copied correctly from source to target after a migrat
 | `--row-count-tolerance <pct>` | 5 | Allowed % difference for `pg_class` row estimates |
 | `--spot-check-tables <n>` | 20 | Number of tables for MIN/MAX spot-check |
 | `--no-spot-check` | — | Skip MIN/MAX spot-check entirely |
-| `--schemas <s1,s2,...>` | all | Restrict checks to specific schemas |
 | `--exact-count-tables <n>` | 10 | Tables to exact-count (0 = skip) |
 | `--exact-count-max-gb <n>` | 10 | Max table size in GB for exact count |
 | `--exact-count-timeout <s>` | 120 | Per-table `COUNT(*)` timeout in seconds |
-| `--filters <path>` | `~/filters.ini` | filters.ini used to scope checks to migrated objects (point at a nonexistent path to compare all objects) |
+| `--filters <path>` | `~/filters.ini` | Path to the filters.ini used to scope checks to migrated objects (required; errors out if absent) |
 
-**filters.ini awareness:** The migration only copies the subset of objects allowed by `~/filters.ini`, so by default this script scopes every check to that same subset — otherwise intentionally-excluded objects (e.g. Supabase's `auth`, `storage`, `realtime` schemas) report as "missing in target" false positives, and the exact-count sampler can even flag an excluded table as confirmed data loss. It honors `[exclude-schema]`/`[include-only-schema]` (all checks), `[exclude-table]`/`[include-only-table]` (table, row-count, spot-check, and exact-count checks), and `[exclude-extension]` (the extensions check), using the same interpretation as `preflight-check.sh`. The active scope is printed in the header. To compare everything regardless, point `--filters` at a nonexistent path (e.g. `--filters /dev/null`). Note: in `include-only-table` mode, non-table objects (views, functions, sequences) are scoped only to the schemas of the included tables, so some may still report as missing.
+**filters.ini awareness:** The migration only copies the subset of objects allowed by `~/filters.ini`, so this script scopes every check to that same subset — otherwise intentionally-excluded objects (e.g. Supabase's `auth`, `storage`, `realtime` schemas) report as "missing in target" false positives, and the exact-count sampler can even flag an excluded table as confirmed data loss. It honors `[exclude-schema]`/`[include-only-schema]` (all checks), `[exclude-table]`/`[include-only-table]` (table, row-count, spot-check, and exact-count checks), and `[exclude-extension]` (the extensions check), using the same interpretation as `preflight-check.sh`. The active scope is printed in the header. filters.ini is **required** — verify uses the same scope the migration ran with, so it errors out if the file is absent; to compare everything, use a filters.ini with no scope sections. Note: in `include-only-table` mode, non-table objects (views, functions, sequences) are scoped only to the schemas of the included tables, so some may still report as missing.
 
 **When to use:** After `pgcopydb` finishes the initial COPY phase and before enabling CDC or cutting over. Run it multiple times — exact-count tables are chosen randomly, so repeated runs cover more tables.
 

--- a/pgcopydb-helpers/AGENTS.md
+++ b/pgcopydb-helpers/AGENTS.md
@@ -64,6 +64,9 @@ Verifies that all data was copied correctly from source to target after a migrat
 | `--exact-count-tables <n>` | 10 | Tables to exact-count (0 = skip) |
 | `--exact-count-max-gb <n>` | 10 | Max table size in GB for exact count |
 | `--exact-count-timeout <s>` | 120 | Per-table `COUNT(*)` timeout in seconds |
+| `--filters <path>` | `~/filters.ini` | filters.ini used to scope checks to migrated objects (point at a nonexistent path to compare all objects) |
+
+**filters.ini awareness:** The migration only copies the subset of objects allowed by `~/filters.ini`, so by default this script scopes every check to that same subset — otherwise intentionally-excluded objects (e.g. Supabase's `auth`, `storage`, `realtime` schemas) report as "missing in target" false positives, and the exact-count sampler can even flag an excluded table as confirmed data loss. It honors `[exclude-schema]`/`[include-only-schema]` (all checks), `[exclude-table]`/`[include-only-table]` (table, row-count, spot-check, and exact-count checks), and `[exclude-extension]` (the extensions check), using the same interpretation as `preflight-check.sh`. The active scope is printed in the header. To compare everything regardless, point `--filters` at a nonexistent path (e.g. `--filters /dev/null`). Note: in `include-only-table` mode, non-table objects (views, functions, sequences) are scoped only to the schemas of the included tables, so some may still report as missing.
 
 **When to use:** After `pgcopydb` finishes the initial COPY phase and before enabling CDC or cutting over. Run it multiple times — exact-count tables are chosen randomly, so repeated runs cover more tables.
 

--- a/pgcopydb-helpers/README.md
+++ b/pgcopydb-helpers/README.md
@@ -212,6 +212,8 @@ To receive Slack alerts for migration events (errors, initial copy completion, s
    ~/verify-migration.sh
    ```
 
+   The script reads `~/filters.ini` and scopes its checks to the objects the migration actually copied, so schemas, tables, and extensions you excluded (for example Supabase's `auth`, `storage`, and `realtime` schemas) are not reported as missing. Pass `--filters <path>` to use a different filter file, or point it at a nonexistent path to compare every object.
+
 6. **Switch** your application to the PlanetScale target.
 
 ### 5. Clean Up

--- a/pgcopydb-helpers/README.md
+++ b/pgcopydb-helpers/README.md
@@ -212,7 +212,7 @@ To receive Slack alerts for migration events (errors, initial copy completion, s
    ~/verify-migration.sh
    ```
 
-   The script reads `~/filters.ini` and scopes its checks to the objects the migration actually copied, so schemas, tables, and extensions you excluded (for example Supabase's `auth`, `storage`, and `realtime` schemas) are not reported as missing. Pass `--filters <path>` to use a different filter file, or point it at a nonexistent path to compare every object.
+   The script reads `~/filters.ini` and scopes its checks to the objects the migration actually copied, so schemas, tables, and extensions you excluded (for example Supabase's `auth`, `storage`, and `realtime` schemas) are not reported as missing. A `filters.ini` is required — verify must use the same scope the migration ran with — so the script errors out if one is not found; pass `--filters <path>` to use a file in a non-default location.
 
 6. **Switch** your application to the PlanetScale target.
 

--- a/pgcopydb-helpers/verify-migration.sh
+++ b/pgcopydb-helpers/verify-migration.sh
@@ -21,6 +21,8 @@
 #   --exact-count-tables <n>      Random tables to exact-count (default: 10, 0=skip)
 #   --exact-count-max-gb <n>      Max table size in GB for exact count (default: 10)
 #   --exact-count-timeout <s>     Per-table COUNT(*) timeout in seconds (default: 120)
+#   --filters <path>              filters.ini to scope checks to migrated objects (default: ~/filters.ini)
+#                                 Point at a nonexistent path (e.g. /dev/null) to compare all objects.
 # =============================================================================
 
 set -uo pipefail
@@ -55,6 +57,7 @@ SCHEMA_FILTER=""       # empty = all non-system schemas
 EXACT_COUNT_N=10       # number of random tables to exact-count
 EXACT_COUNT_MAX_GB=10  # tables larger than this are skipped
 EXACT_COUNT_TIMEOUT=120
+FILTERS_FILE=~/filters.ini  # scope checks to objects this filter migrates
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 usage() {
@@ -94,6 +97,111 @@ line_count() { printf '%s' "${1:-}" | grep -c . || true; }
 # Absolute value
 abs() { local v=$1; echo "${v#-}"; }
 
+# ── filters.ini scope helpers ─────────────────────────────────────────────────
+# The migration only copies the subset of objects allowed by ~/filters.ini.
+# Without this awareness, intentionally-excluded objects (e.g. Supabase's auth,
+# storage, realtime schemas) show up as "missing in target" — false-positive
+# noise. These helpers mirror preflight-check.sh's interpretation of filters.ini.
+
+# Parse scope-relevant sections from filters.ini into global arrays
+parse_filters_ini() {
+    local ini_file="$1"
+    FILTER_EXCLUDE_SCHEMAS=(); FILTER_EXCLUDE_TABLES=()
+    FILTER_INCLUDE_ONLY_TABLES=(); FILTER_INCLUDE_ONLY_SCHEMAS=()
+    FILTER_EXCLUDE_EXTENSIONS=()
+    local section="" line
+    while IFS= read -r line; do
+        line="${line#"${line%%[![:space:]]*}"}"   # ltrim
+        line="${line%"${line##*[![:space:]]}"}"   # rtrim
+        [[ -z "$line" || "$line" == \#* ]] && continue
+        if [[ "$line" =~ ^\[(.+)\]$ ]]; then section="${BASH_REMATCH[1]}"; continue; fi
+        case "$section" in
+            exclude-schema)      FILTER_EXCLUDE_SCHEMAS+=("$line")      ;;
+            exclude-table)       FILTER_EXCLUDE_TABLES+=("$line")       ;;
+            include-only-table)  FILTER_INCLUDE_ONLY_TABLES+=("$line")  ;;
+            include-only-schema) FILTER_INCLUDE_ONLY_SCHEMAS+=("$line") ;;
+            exclude-extension)   FILTER_EXCLUDE_EXTENSIONS+=("$line")   ;;
+        esac
+    done < "$ini_file"
+}
+
+# Returns the effective filter mode: include-table | include-schema | exclude-schema | all
+filter_scope_mode() {
+    [ ${#FILTER_INCLUDE_ONLY_TABLES[@]} -gt 0 ]  && { echo "include-table";  return; }
+    [ ${#FILTER_INCLUDE_ONLY_SCHEMAS[@]} -gt 0 ] && { echo "include-schema"; return; }
+    [ ${#FILTER_EXCLUDE_SCHEMAS[@]} -gt 0 ]      && { echo "exclude-schema"; return; }
+    echo "all"
+}
+
+# Formats values as a SQL-safe single-quoted comma list: 'a','b','c'
+_sql_list() {
+    local result="" v sq="'"
+    for v in "$@"; do
+        v="${v//$sq/$sq$sq}"
+        result="${result:+$result,}'${v}'"
+    done
+    echo "$result"
+}
+
+# Build SQL-quoted list of unique schema names extracted from "schema.table" entries
+_it_schema_sql_list() {
+    local result="" sq="'"
+    while IFS= read -r s; do
+        s="${s//$sq/$sq$sq}"
+        result="${result:+$result,}'${s}'"
+    done < <(printf '%s\n' "$@" | cut -d. -f1 | sort -u)
+    echo "$result"
+}
+
+# schema_clause <schema-column-expr> — "AND <col> IN/NOT IN (...)" or "" for all mode.
+# Applied to every object type so excluded/included schemas scope the whole comparison.
+schema_clause() {
+    local col="$1" mode list
+    mode=$(filter_scope_mode)
+    case "$mode" in
+        include-table)  list=$(_it_schema_sql_list "${FILTER_INCLUDE_ONLY_TABLES[@]}"); echo "AND ${col} IN (${list})" ;;
+        include-schema) list=$(_sql_list "${FILTER_INCLUDE_ONLY_SCHEMAS[@]}");          echo "AND ${col} IN (${list})" ;;
+        exclude-schema) list=$(_sql_list "${FILTER_EXCLUDE_SCHEMAS[@]}");               echo "AND ${col} NOT IN (${list})" ;;
+        all)            echo "" ;;
+    esac
+}
+
+# table_clause <schema-col> <rel-col> — restricts table-keyed checks to the
+# in-scope table set. " AND (<schema>.<rel>) IN/NOT IN (...)" or "".
+table_clause() {
+    local scol="$1" rcol="$2" mode
+    mode=$(filter_scope_mode)
+    if [ "$mode" = "include-table" ]; then
+        echo " AND (${scol} || '.' || ${rcol}) IN ($(_sql_list "${FILTER_INCLUDE_ONLY_TABLES[@]}"))"
+    elif [ ${#FILTER_EXCLUDE_TABLES[@]} -gt 0 ]; then
+        echo " AND (${scol} || '.' || ${rcol}) NOT IN ($(_sql_list "${FILTER_EXCLUDE_TABLES[@]}"))"
+    else
+        echo ""
+    fi
+}
+
+# extension_clause <extname-col> — excludes [exclude-extension] entries, or "".
+extension_clause() {
+    local col="$1"
+    [ ${#FILTER_EXCLUDE_EXTENSIONS[@]} -eq 0 ] && { echo ""; return; }
+    echo "AND ${col} NOT IN ($(_sql_list "${FILTER_EXCLUDE_EXTENSIONS[@]}"))"
+}
+
+# Human-readable one-line summary of the active scope
+filter_scope_describe() {
+    case "$(filter_scope_mode)" in
+        include-table)  echo "include-only-table (${#FILTER_INCLUDE_ONLY_TABLES[@]} table(s))" ;;
+        include-schema) echo "include-only-schema (${#FILTER_INCLUDE_ONLY_SCHEMAS[@]} schema(s))" ;;
+        exclude-schema) echo "exclude-schema (${#FILTER_EXCLUDE_SCHEMAS[@]} schema(s))$([ ${#FILTER_EXCLUDE_TABLES[@]} -gt 0 ] && echo " + exclude-table (${#FILTER_EXCLUDE_TABLES[@]})")" ;;
+        all)            [ ${#FILTER_EXCLUDE_TABLES[@]} -gt 0 ] && { echo "exclude-table (${#FILTER_EXCLUDE_TABLES[@]} table(s))"; return; }; echo "none" ;;
+    esac
+}
+
+# Arrays must exist before any helper references them (set -u)
+FILTER_EXCLUDE_SCHEMAS=(); FILTER_EXCLUDE_TABLES=()
+FILTER_INCLUDE_ONLY_TABLES=(); FILTER_INCLUDE_ONLY_SCHEMAS=()
+FILTER_EXCLUDE_EXTENSIONS=()
+
 # ── Argument parsing ──────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -104,6 +212,7 @@ while [[ $# -gt 0 ]]; do
         --exact-count-tables)   EXACT_COUNT_N="$2"; shift 2 ;;
         --exact-count-max-gb)   EXACT_COUNT_MAX_GB="$2"; shift 2 ;;
         --exact-count-timeout)  EXACT_COUNT_TIMEOUT="$2"; shift 2 ;;
+        --filters)              FILTERS_FILE="$2"; shift 2 ;;
         -h|--help)              usage ;;
         *) echo "Unknown option: $1"; usage ;;
     esac
@@ -117,6 +226,17 @@ if [[ -n "$SCHEMA_FILTER" ]]; then
 else
     SCHEMA_SQL_FILTER="AND n.nspname NOT IN ('pg_catalog','information_schema','pg_toast')"
     SCHEMA_SQL_FILTER_PLAIN="AND table_schema NOT IN ('pg_catalog','information_schema','pg_toast')"
+fi
+
+# Load filters.ini so checks are scoped to what the migration actually copies.
+# Arrays stay empty (→ all helpers return "") when the file is absent, preserving
+# the original compare-everything behaviour. Point --filters at a nonexistent
+# path (e.g. /dev/null) to deliberately compare all objects.
+if [[ -f "$FILTERS_FILE" ]]; then
+    parse_filters_ini "$FILTERS_FILE"
+    FILTER_DESC="$FILTERS_FILE — $(filter_scope_describe)"
+else
+    FILTER_DESC="$FILTERS_FILE not found — comparing all objects"
 fi
 
 # ── Prerequisite check ────────────────────────────────────────────────────────
@@ -135,6 +255,7 @@ echo -e "  Source : ${CYAN}$(echo "$SOURCE_CONN" | sed 's/:\/\/[^:]*:[^@]*@/:\/\
 echo -e "  Target : ${CYAN}$(echo "$TARGET_CONN" | sed 's/:\/\/[^:]*:[^@]*@/:\/\/***:***@/')${NC}"
 echo -e "  Time   : $(date)"
 echo -e "  Options: row_tolerance=${ROW_TOLERANCE}%  spot_check_tables=${SPOT_CHECK_N}"
+echo -e "  Filters: ${CYAN}${FILTER_DESC}${NC}"
 
 # =============================================================================
 # 1. CONNECTIONS
@@ -192,6 +313,7 @@ TABLE_QUERY="
     FROM pg_class c
     JOIN pg_namespace n ON n.oid = c.relnamespace
     WHERE c.relkind = 'r' $SCHEMA_SQL_FILTER
+    $(schema_clause "n.nspname") $(table_clause "n.nspname" "c.relname")
     ORDER BY 1"
 
 SRC_TABLES=$(q "$SOURCE_CONN" "$TABLE_QUERY")
@@ -239,6 +361,7 @@ COL_QUERY="
         || '  default=' || COALESCE(column_default, 'NULL')
     FROM information_schema.columns
     WHERE true $SCHEMA_SQL_FILTER_PLAIN
+    $(schema_clause "table_schema") $(table_clause "table_schema" "table_name")
     ORDER BY table_schema, table_name, ordinal_position"
 
 SRC_COLS=$(q "$SOURCE_CONN" "$COL_QUERY")
@@ -272,6 +395,7 @@ IDX_QUERY="
     WHERE true
     AND schemaname NOT IN ('pg_catalog','information_schema','pg_toast')
     $( [[ -n "$SCHEMA_FILTER" ]] && echo "AND schemaname IN ($(echo "$SCHEMA_FILTER" | sed "s/,/','/g; s/^/'/; s/$/'/" ))" || true )
+    $(schema_clause "schemaname") $(table_clause "schemaname" "tablename")
     ORDER BY 1"
 
 SRC_IDX=$(q "$SOURCE_CONN" "$IDX_QUERY")
@@ -301,6 +425,7 @@ CON_QUERY="
     JOIN pg_class t     ON t.oid = c.conrelid
     JOIN pg_namespace n ON n.oid = t.relnamespace
     WHERE true $SCHEMA_SQL_FILTER
+    $(schema_clause "n.nspname") $(table_clause "n.nspname" "t.relname")
     ORDER BY 1"
 
 SRC_CON=$(q "$SOURCE_CONN" "$CON_QUERY")
@@ -324,6 +449,7 @@ VIEW_QUERY="
     FROM pg_views
     WHERE schemaname NOT IN ('pg_catalog','information_schema')
     $( [[ -n "$SCHEMA_FILTER" ]] && echo "AND schemaname IN ($(echo "$SCHEMA_FILTER" | sed "s/,/','/g; s/^/'/; s/$/'/" ))" || true )
+    $(schema_clause "schemaname")
     ORDER BY 1"
 
 SRC_VIEWS=$(q "$SOURCE_CONN" "$VIEW_QUERY")
@@ -349,6 +475,7 @@ FUNC_QUERY="
     FROM pg_proc p
     JOIN pg_namespace n ON n.oid = p.pronamespace
     WHERE true $SCHEMA_SQL_FILTER
+    $(schema_clause "n.nspname")
     ORDER BY 1"
 
 SRC_FUNCS=$(q "$SOURCE_CONN" "$FUNC_QUERY")
@@ -374,6 +501,7 @@ ROWCNT_QUERY="
     FROM pg_class c
     JOIN pg_namespace n ON n.oid = c.relnamespace
     WHERE c.relkind = 'r' $SCHEMA_SQL_FILTER
+    $(schema_clause "n.nspname") $(table_clause "n.nspname" "c.relname")
     ORDER BY c.reltuples DESC"
 
 SRC_ROWCNTS=$(q "$SOURCE_CONN" "$ROWCNT_QUERY")
@@ -388,11 +516,11 @@ while IFS=$'\t' read -r tbl src_n tgt_n; do
         diff=$(abs $((src_n - tgt_n)))
         pct=$(( diff * 100 / src_n ))
         if [[ $pct -gt $ROW_TOLERANCE ]]; then
-            RC_MISMATCH_OUT+="$(printf "       %-55s  src=%12d  tgt=%12d  diff=%d%%\n" "$tbl" "$src_n" "$tgt_n" "$pct")"
+            RC_MISMATCH_OUT+="$(printf "       %-55s  src=%12d  tgt=%12d  diff=%d%%" "$tbl" "$src_n" "$tgt_n" "$pct")"$'\n'
             RC_MISMATCH_COUNT=$(( RC_MISMATCH_COUNT + 1 ))
         fi
     elif [[ "${tgt_n:-0}" -ne 0 ]]; then
-        RC_MISMATCH_OUT+="$(printf "       %-55s  src=%12d  tgt=%12d  diff=src_empty_tgt_not\n" "$tbl" "$src_n" "$tgt_n")"
+        RC_MISMATCH_OUT+="$(printf "       %-55s  src=%12d  tgt=%12d  diff=src_empty_tgt_not" "$tbl" "$src_n" "$tgt_n")"$'\n'
         RC_MISMATCH_COUNT=$(( RC_MISMATCH_COUNT + 1 ))
     fi
 done < <(join -t$'\t' \
@@ -418,6 +546,7 @@ SEQ_QUERY="
     FROM pg_class c
     JOIN pg_namespace n ON n.oid = c.relnamespace
     WHERE c.relkind = 'S' $SCHEMA_SQL_FILTER
+    $(schema_clause "n.nspname")
     ORDER BY 1"
 
 SRC_SEQS=$(q "$SOURCE_CONN" "$SEQ_QUERY")
@@ -436,6 +565,7 @@ SEQ_VAL_QUERY="
     SELECT schemaname || '.' || sequencename, last_value
     FROM pg_sequences
     WHERE schemaname NOT IN ('pg_catalog','information_schema')
+    $(schema_clause "schemaname")
     ORDER BY 1"
 
 SRC_SEQVALS=$(q "$SOURCE_CONN" "$SEQ_VAL_QUERY")
@@ -482,6 +612,7 @@ else
         WHERE c.contype = 'p'
           AND array_length(c.conkey, 1) = 1
           $SCHEMA_SQL_FILTER
+          $(schema_clause "n.nspname") $(table_clause "n.nspname" "t.relname")
         ORDER BY sz.reltuples DESC
         LIMIT $SPOT_CHECK_N"
 
@@ -547,6 +678,7 @@ else
         WHERE c.relkind = 'r'
           AND pg_total_relation_size(c.oid) BETWEEN 1 AND ${EXACT_MAX_BYTES}
           $SCHEMA_SQL_FILTER
+          $(schema_clause "n.nspname") $(table_clause "n.nspname" "c.relname")
         ORDER BY random()
         LIMIT ${EXACT_COUNT_N}"
 
@@ -627,7 +759,8 @@ fi
 # =============================================================================
 log_section "BONUS  EXTENSIONS"
 
-EXT_QUERY="SELECT extname || '  version=' || extversion FROM pg_extension ORDER BY 1"
+EXT_QUERY="SELECT extname || '  version=' || extversion FROM pg_extension
+    WHERE true $(extension_clause "extname") ORDER BY 1"
 SRC_EXT=$(q "$SOURCE_CONN" "$EXT_QUERY")
 TGT_EXT=$(q "$TARGET_CONN" "$EXT_QUERY")
 

--- a/pgcopydb-helpers/verify-migration.sh
+++ b/pgcopydb-helpers/verify-migration.sh
@@ -17,12 +17,11 @@
 #   --row-count-tolerance <pct>   Allowed % difference for row estimates (default: 5)
 #   --spot-check-tables <n>       Number of largest tables to spot-check (default: 20)
 #   --no-spot-check               Skip min/max spot-check (fastest mode)
-#   --schemas <s1,s2,...>         Only check these schemas (default: all non-system)
 #   --exact-count-tables <n>      Random tables to exact-count (default: 10, 0=skip)
 #   --exact-count-max-gb <n>      Max table size in GB for exact count (default: 10)
 #   --exact-count-timeout <s>     Per-table COUNT(*) timeout in seconds (default: 120)
-#   --filters <path>              filters.ini to scope checks to migrated objects (default: ~/filters.ini)
-#                                 Point at a nonexistent path (e.g. /dev/null) to compare all objects.
+#   --filters <path>              Path to filters.ini (default: ~/filters.ini). Required —
+#                                 verify scopes to the same object set the migration used.
 # =============================================================================
 
 set -uo pipefail
@@ -53,7 +52,6 @@ PASS=0; FAIL=0; WARN=0
 ROW_TOLERANCE=5
 SPOT_CHECK_N=20
 NO_SPOT_CHECK=false
-SCHEMA_FILTER=""       # empty = all non-system schemas
 EXACT_COUNT_N=10       # number of random tables to exact-count
 EXACT_COUNT_MAX_GB=10  # tables larger than this are skipped
 EXACT_COUNT_TIMEOUT=120
@@ -208,7 +206,6 @@ while [[ $# -gt 0 ]]; do
         --row-count-tolerance)  ROW_TOLERANCE="$2"; shift 2 ;;
         --spot-check-tables)    SPOT_CHECK_N="$2"; shift 2 ;;
         --no-spot-check)        NO_SPOT_CHECK=true; shift ;;
-        --schemas)              SCHEMA_FILTER="$2"; shift 2 ;;
         --exact-count-tables)   EXACT_COUNT_N="$2"; shift 2 ;;
         --exact-count-max-gb)   EXACT_COUNT_MAX_GB="$2"; shift 2 ;;
         --exact-count-timeout)  EXACT_COUNT_TIMEOUT="$2"; shift 2 ;;
@@ -218,25 +215,21 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Build schema exclusion / inclusion clause used in most queries
-if [[ -n "$SCHEMA_FILTER" ]]; then
-    # Convert comma list → SQL IN list
-    SCHEMA_SQL_FILTER="AND n.nspname IN ($(echo "$SCHEMA_FILTER" | sed "s/,/','/g; s/^/'/; s/$/'/" ))"
-    SCHEMA_SQL_FILTER_PLAIN="AND table_schema IN ($(echo "$SCHEMA_FILTER" | sed "s/,/','/g; s/^/'/; s/$/'/" ))"
-else
-    SCHEMA_SQL_FILTER="AND n.nspname NOT IN ('pg_catalog','information_schema','pg_toast')"
-    SCHEMA_SQL_FILTER_PLAIN="AND table_schema NOT IN ('pg_catalog','information_schema','pg_toast')"
-fi
+# Always-required system-schema exclusion (independent of filters.ini)
+SCHEMA_SQL_FILTER="AND n.nspname NOT IN ('pg_catalog','information_schema','pg_toast')"
+SCHEMA_SQL_FILTER_PLAIN="AND table_schema NOT IN ('pg_catalog','information_schema','pg_toast')"
 
-# Load filters.ini so checks are scoped to what the migration actually copies.
-# Arrays stay empty (→ all helpers return "") when the file is absent, preserving
-# the original compare-everything behaviour. Point --filters at a nonexistent
-# path (e.g. /dev/null) to deliberately compare all objects.
+# Load filters.ini so checks are scoped to the exact object set the migration copied.
+# filters.ini is required: verify must use the same scope the migration ran with, so the
+# same file governs both.
 if [[ -f "$FILTERS_FILE" ]]; then
     parse_filters_ini "$FILTERS_FILE"
     FILTER_DESC="$FILTERS_FILE — $(filter_scope_describe)"
 else
-    FILTER_DESC="$FILTERS_FILE not found — comparing all objects"
+    echo -e "${RED}Error:${NC} filters.ini not found at ${FILTERS_FILE}" >&2
+    echo "  verify-migration.sh scopes its checks to the same object set the migration" >&2
+    echo "  used, so a filters.ini is required. Create ~/filters.ini, or pass --filters <path>." >&2
+    exit 1
 fi
 
 # ── Prerequisite check ────────────────────────────────────────────────────────
@@ -394,7 +387,6 @@ IDX_QUERY="
     FROM pg_indexes
     WHERE true
     AND schemaname NOT IN ('pg_catalog','information_schema','pg_toast')
-    $( [[ -n "$SCHEMA_FILTER" ]] && echo "AND schemaname IN ($(echo "$SCHEMA_FILTER" | sed "s/,/','/g; s/^/'/; s/$/'/" ))" || true )
     $(schema_clause "schemaname") $(table_clause "schemaname" "tablename")
     ORDER BY 1"
 
@@ -448,7 +440,6 @@ VIEW_QUERY="
     SELECT schemaname || '.' || viewname
     FROM pg_views
     WHERE schemaname NOT IN ('pg_catalog','information_schema')
-    $( [[ -n "$SCHEMA_FILTER" ]] && echo "AND schemaname IN ($(echo "$SCHEMA_FILTER" | sed "s/,/','/g; s/^/'/; s/$/'/" ))" || true )
     $(schema_clause "schemaname")
     ORDER BY 1"
 


### PR DESCRIPTION
Scopes verify checks to the objects the migration actually copies (per `~/filters.ini`), so excluded schemas/tables/extensions — e.g. Supabase's `auth`/`storage`/`realtime` — no longer show as false "missing in target" failures. Uses the same filters.ini interpretation as `preflight-check.sh`. No filter file → unchanged behaviour; `--filters <path>` overrides.

Also fixes a pre-existing formatting bug where §8 row-count mismatch rows ran together on one line (lost newline from `$(printf …)`).