### PR TITLE
Enforce read-only sessions on diagnostic scripts

### DIFF
--- a/pgcopydb-helpers/AGENTS.md
+++ b/pgcopydb-helpers/AGENTS.md
@@ -34,6 +34,8 @@ Compares performance-relevant PostgreSQL parameters between source and target da
 
 **Requires:** `PGCOPYDB_SOURCE_PGURI`, `PGCOPYDB_TARGET_PGURI`
 
+**Read-only** — connects with `default_transaction_read_only=on`, a statement timeout, and a lock timeout; makes no modifications.
+
 ---
 
 #### `verify-migration.sh`
@@ -75,7 +77,7 @@ Verifies that all data was copied correctly from source to target after a migrat
 
 **Requires:** `PGCOPYDB_SOURCE_PGURI`, `PGCOPYDB_TARGET_PGURI`
 
-**Read-only** — makes no modifications to either database.
+**Read-only** — connects with `default_transaction_read_only=on`; makes no modifications to either database. No global statement timeout: exact-count `COUNT(*)` queries set their own via `--exact-count-timeout`.
 
 ---
 
@@ -98,7 +100,7 @@ Validates all migration prerequisites before starting `pgcopydb clone --follow`.
 
 **Exit code:** 0 if no FAILs, 1 if any FAILs.
 
-**Read-only** — makes no modifications to either database.
+**Read-only** — connects with `default_transaction_read_only=on`, a statement timeout, and a lock timeout; makes no modifications to either database.
 
 ---
 
@@ -254,6 +256,8 @@ Displays a full migration progress dashboard: phase completion status, table/ind
 
 **Requires:** `PGCOPYDB_TARGET_PGURI` (for active operations query). Reads from the most recent `~/migration_*` directory.
 
+**Read-only** — connects with `default_transaction_read_only=on`, a statement timeout, and a lock timeout; makes no modifications.
+
 ---
 
 #### `check-cdc-status.sh`
@@ -276,6 +280,8 @@ Displays CDC-specific replication progress: apply and streaming LSN positions, b
 **Key indicator:** "CDC IS CAUGHT UP" (gap < 100 MB) means you can proceed with cutover.
 
 **Requires:** `PGCOPYDB_SOURCE_PGURI`, `PGCOPYDB_TARGET_PGURI`
+
+**Read-only** — connects with `default_transaction_read_only=on`, a statement timeout, and a lock timeout; makes no modifications.
 
 ---
 

--- a/pgcopydb-helpers/check-cdc-status.sh
+++ b/pgcopydb-helpers/check-cdc-status.sh
@@ -15,6 +15,13 @@ source ~/.env
 set +a
 set -u
 
+# --- Read-only safety belt ---
+# This script only reads. default_transaction_read_only blocks any accidental
+# write, and the statement/lock timeouts keep a check from hanging on a busy
+# database — important when querying the live source. Exported so every psql call
+# inherits it.
+export PGOPTIONS='-c default_transaction_read_only=on -c statement_timeout=30000 -c lock_timeout=5000'
+
 # --- Configuration ---
 MIGRATION_DIR="${MIGRATION_DIR:-$(ls -dt ~/migration_*/ 2>/dev/null | head -1 || true)}"
 

--- a/pgcopydb-helpers/check-migration-status.sh
+++ b/pgcopydb-helpers/check-migration-status.sh
@@ -27,6 +27,13 @@ source ~/.env
 set +a
 set -u
 
+# --- Read-only safety belt ---
+# This script only reads. default_transaction_read_only blocks any accidental
+# write, and the statement/lock timeouts keep a check from hanging on a busy
+# database — important when querying the live source. Exported so every psql call
+# inherits it.
+export PGOPTIONS='-c default_transaction_read_only=on -c statement_timeout=30000 -c lock_timeout=5000'
+
 MIGRATION_DIR="${MIGRATION_DIR:-$(ls -dt ~/migration_*/ 2>/dev/null | head -1 || true)}"
 if [ -z "$MIGRATION_DIR" ]; then
     echo -e "${RED}✗ No migration directory found${NC}"

--- a/pgcopydb-helpers/compare-pg-params.sh
+++ b/pgcopydb-helpers/compare-pg-params.sh
@@ -17,6 +17,13 @@ source ~/.env
 set +a
 set -u
 
+# --- Read-only safety belt ---
+# This script only reads. default_transaction_read_only blocks any accidental
+# write, and the statement/lock timeouts keep a diagnostic from hanging on a busy
+# database — important when querying the live source. Exported so every psql call
+# inherits it.
+export PGOPTIONS='-c default_transaction_read_only=on -c statement_timeout=30000 -c lock_timeout=5000'
+
 if [ -z "${PGCOPYDB_SOURCE_PGURI:-}" ] || [ -z "${PGCOPYDB_TARGET_PGURI:-}" ]; then
     echo "ERROR: PGCOPYDB_SOURCE_PGURI and PGCOPYDB_TARGET_PGURI must be set in ~/.env"
     exit 1

--- a/pgcopydb-helpers/preflight-check.sh
+++ b/pgcopydb-helpers/preflight-check.sh
@@ -20,6 +20,13 @@ source ~/.env
 set +a
 set -u
 
+# --- Read-only safety belt ---
+# This script only reads. default_transaction_read_only blocks any accidental
+# write, and the statement/lock timeouts keep a check from hanging on a busy
+# database — important when querying the live source. Exported so every psql call
+# inherits it.
+export PGOPTIONS='-c default_transaction_read_only=on -c statement_timeout=30000 -c lock_timeout=5000'
+
 if [ -z "${PGCOPYDB_SOURCE_PGURI:-}" ] || [ -z "${PGCOPYDB_TARGET_PGURI:-}" ]; then
     echo "ERROR: PGCOPYDB_SOURCE_PGURI and PGCOPYDB_TARGET_PGURI must be set in ~/.env"
     exit 1

--- a/pgcopydb-helpers/verify-migration.sh
+++ b/pgcopydb-helpers/verify-migration.sh
@@ -33,6 +33,14 @@ source ~/.env
 set +a
 set -u
 
+# ── Read-only safety belt ─────────────────────────────────────────────────────
+# verify only reads. default_transaction_read_only blocks any accidental write.
+# No global statement_timeout here: exact-count COUNT(*) queries set their own
+# (--exact-count-timeout), and a short lock_timeout could turn a transient lock on
+# a busy source into a false verification failure. Exported so every psql call
+# inherits it.
+export PGOPTIONS='-c default_transaction_read_only=on'
+
 if [[ -z "${PGCOPYDB_SOURCE_PGURI:-}" || -z "${PGCOPYDB_TARGET_PGURI:-}" ]]; then
     echo "ERROR: PGCOPYDB_SOURCE_PGURI and PGCOPYDB_TARGET_PGURI must be set in ~/.env"
     exit 1


### PR DESCRIPTION
Adds a read-only safety belt to the scripts that only ever read, via an exported `PGOPTIONS`.

## What

| Script | Guard |
|---|---|
| `compare-pg-params.sh` | `default_transaction_read_only=on` + `statement_timeout=30s` + `lock_timeout=5s` |
| `check-cdc-status.sh` | full (as above) |
| `check-migration-status.sh` | full |
| `preflight-check.sh` | full |
| `verify-migration.sh` | `read_only` only — it manages its own per-table `COUNT(*)` timeout via `--exact-count-timeout`, and a short `lock_timeout` could turn a transient lock on a busy source into a false verification failure |

## Why

These are diagnostics that should never write. `default_transaction_read_only=on` makes accidental writes impossible even if a query is later edited; the statement/lock timeouts keep a check from hanging on a busy database — important since several query the live source.

## Notes

- Applied as a single `export PGOPTIONS` after each script's env load, so every existing `psql` call inherits it with no per-call changes.
- Confirmed all five scripts are write-free before adding `read_only=on`.
- `bash -n` passes on all five.
- AGENTS.md read-only notes updated to state the actual enforcement.

No automated test suite in this repo; validated by syntax check and code inspection.