### PR TITLE
Do not abort migration when core ulimit cannot be raised

### DIFF
--- a/pgcopydb-helpers/resume-cdc.sh
+++ b/pgcopydb-helpers/resume-cdc.sh
@@ -43,8 +43,14 @@ FILTER_FILE=~/filters.ini
 TABLE_JOBS=16
 
 cd "$MIGRATION_DIR"
-ulimit -c unlimited
-echo "$MIGRATION_DIR/core.%e.%p" | sudo tee /proc/sys/kernel/core_pattern
+# Core dumps help debug rare native crashes; not required for a successful migrate.
+# SSM sessions often cannot raise the core ulimit — do not abort if this fails.
+if ! ulimit -c unlimited 2>/dev/null; then
+    echo "WARN: could not raise core ulimit (common under SSM); continuing without core dumps" >&2
+fi
+if ! echo "$MIGRATION_DIR/core.%e.%p" | sudo tee /proc/sys/kernel/core_pattern; then
+    echo "WARN: could not set kernel.core_pattern; continuing without core dumps" >&2
+fi
 
 # --- Locate pgcopydb: prefer PATH, else highest-versioned PG install ---
 find_pgcopydb() {

--- a/pgcopydb-helpers/resume-migration.sh
+++ b/pgcopydb-helpers/resume-migration.sh
@@ -58,8 +58,14 @@ TABLE_JOBS=16
 INDEX_JOBS=12
 
 cd "$MIGRATION_DIR"
-ulimit -c unlimited
-echo "$MIGRATION_DIR/core.%e.%p" | sudo tee /proc/sys/kernel/core_pattern
+# Core dumps help debug rare native crashes; not required for a successful migrate.
+# SSM sessions often cannot raise the core ulimit — do not abort if this fails.
+if ! ulimit -c unlimited 2>/dev/null; then
+    echo "WARN: could not raise core ulimit (common under SSM); continuing without core dumps" >&2
+fi
+if ! echo "$MIGRATION_DIR/core.%e.%p" | sudo tee /proc/sys/kernel/core_pattern; then
+    echo "WARN: could not set kernel.core_pattern; continuing without core dumps" >&2
+fi
 
 # Back up SQLite catalog before resume
 cp "$MIGRATION_DIR/schema/source.db" "$MIGRATION_DIR/schema/source.db.bak.$(date +%Y%m%d-%H%M%S)"

--- a/pgcopydb-helpers/run-migration.sh
+++ b/pgcopydb-helpers/run-migration.sh
@@ -44,8 +44,14 @@ INDEX_JOBS=12
 
 mkdir -p "$MIGRATION_DIR"
 cd "$MIGRATION_DIR"
-ulimit -c unlimited
-echo "$MIGRATION_DIR/core.%e.%p" | sudo tee /proc/sys/kernel/core_pattern
+# Core dumps help debug rare native crashes; not required for a successful migrate.
+# SSM sessions often cannot raise the core ulimit — do not abort if this fails.
+if ! ulimit -c unlimited 2>/dev/null; then
+    echo "WARN: could not raise core ulimit (common under SSM); continuing without core dumps" >&2
+fi
+if ! echo "$MIGRATION_DIR/core.%e.%p" | sudo tee /proc/sys/kernel/core_pattern; then
+    echo "WARN: could not set kernel.core_pattern; continuing without core dumps" >&2
+fi
 
 {
     echo ""


### PR DESCRIPTION
## Why

Our AWS templates document **SSM Session Manager as the primary way onto the
migration instance** — it is the connect step in both
`pgcopydb-templates/aws-cloudformation/README-pgcopydb-cfn.md` ("Connect via SSM
Session Manager (no SSH key needed)") and
`pgcopydb-templates/aws-terraform/README-pgcopydb-aws-tf.md`, both stacks attach
`AmazonSSMManagedInstanceCore`, and the EC2 key pair is an optional parameter. A
user who follows the templates as written may never create an SSH key.

On that path, `ulimit -c unlimited` frequently fails with "Operation not
permitted", because the session's inherited hard `core` limit forbids the raise.
All three helper scripts run under `set -eo pipefail`
(`run-migration.sh:9`, `resume-migration.sh:14`, `resume-cdc.sh:15`), so that
non-zero exit terminated the script **before `pgcopydb clone` ever started**.

The failure is also silent in the worst way: `start-migration-screen.sh` returns
successfully after `screen -dmS` and prints "Migration started in screen session
'migration'", while the script inside the screen has already exited. What the user
sees is a nearly empty `~/migration_*` directory, no useful `migration.log`, and
nothing running — with no indication that a core-dump nicety was the cause.

## What

`run-migration.sh`, `resume-migration.sh`, and `resume-cdc.sh` now attempt the
core-dump setup and **warn instead of aborting** when either step fails. Core
dumps are optional crash-debug artifacts; they are not a prerequisite for a
successful migration, so they should never gate the copy.

Both steps are guarded, not just the `ulimit`. Under `pipefail`, a failing
`sudo tee /proc/sys/kernel/core_pattern` is equally fatal, so a `|| true` on only
the first line would have left half the bug in place.

## Verification

- `bash -n` clean on all three scripts.
- Simulated SSM denial (`ulimit -Hc 0`, then the guarded block): prints the WARN
  and continues past the core setup, exit 0. The same denial against the code on
  `main` reproduces the bug exactly — `ulimit: core file size: cannot modify
  limit: Operation not permitted`, exit 1, clone never reached.
- Unrestricted shell: soft limit is raised to `unlimited`, no WARN, behavior
  unchanged for SSH / EC2 Instance Connect users.
- `core_pattern` write failure (simulated under `set -eo pipefail`): warns and
  continues, exit 0.

## Not in scope

- `start-migration-screen.sh` reporting success unconditionally after
  `screen -dmS`. A liveness check there is a worthwhile follow-up but is not
  needed to fix this.
- File-descriptor / `nofile` limits, which are configured separately in user-data
  and `limits.conf`.
